### PR TITLE
Mobile fixes

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,13 +40,13 @@ export default function Header() {
 
                     <span
                         className='text-center align-middle p-2'
-                        style={{fontSize: 20, whiteSpace: "nowrap"}}
+                        style={{fontSize: 16, whiteSpace: "nowrap"}}
                     >
                         <a href={REPO_URL} style={{color: "white"}} target="_blank">
                             Fedialgo Demo
                         </a>
 
-                        {' '}<span style={{color: "lightgrey", fontSize: 14}}>(
+                        {' '}<span style={{color: "lightgrey", fontSize: 10}}>(
                             <a href={CHANGELOG_URL} style={{color: "grey"}} target="_blank">
                                 v{process.env.FEDIALGO_VERSION}
                             </a>

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -134,7 +134,7 @@ export default function Feed() {
                         <div style={stickySwitchContainer}>
                             <Form.Check
                                 checked={isControlPanelSticky}
-                                className="mb-3 d-none d-sm-block"  // bootstrap spacing info: https://getbootstrap.com/docs/5.1/utilities/spacing/
+                                className="d-none d-sm-block"  // bootstrap spacing info: https://getbootstrap.com/docs/5.1/utilities/spacing/
                                 key={"stickPanel"}
                                 label={`Stick Control Panel To Top`}
                                 onChange={(e) => setIsControlPanelSticky(e.target.checked)}
@@ -143,7 +143,6 @@ export default function Feed() {
 
                             <Form.Check
                                 checked={hideLinkPreviews}
-                                className="mb-3"
                                 key={"linkPreviews"}
                                 label={`Hide Link Previews`}
                                 onChange={(e) => setHideLinkPreviews(e.target.checked)}
@@ -158,7 +157,6 @@ export default function Feed() {
                             >
                                 <Form.Check
                                     checked={shouldAutoUpdate}
-                                    className="mb-3"
                                     key={"autoLoadNewToots"}
                                     label={`Auto Load New Toots`}
                                     onChange={(e) => setShouldAutoUpdate(e.target.checked)}

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -177,7 +177,7 @@ export default function Feed() {
                                 ? <LoadingSpinner message={loadingStatus} style={loadingMsgStyle} />
                                 : finishedLoadingMsg(algorithm?.lastLoadTimeInSeconds)}
 
-                            <p style={scrollStatusMsg}>
+                            <p style={scrollStatusMsg} className='d-none d-sm-block'>
                                 {`Displaying ${numDisplayedToots} Toots (Scroll: ${scrollPercentage.toFixed(1)}%)`}
                             </p>
                         </div>

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -134,7 +134,7 @@ export default function Feed() {
                         <div style={stickySwitchContainer}>
                             <Form.Check
                                 checked={isControlPanelSticky}
-                                className="mb-3"  // bootstrap spacing info: https://getbootstrap.com/docs/5.1/utilities/spacing/
+                                className="mb-3 d-none d-sm-block"  // bootstrap spacing info: https://getbootstrap.com/docs/5.1/utilities/spacing/
                                 key={"stickPanel"}
                                 label={`Stick Control Panel To Top`}
                                 onChange={(e) => setIsControlPanelSticky(e.target.checked)}

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -231,7 +231,7 @@ export default function Feed() {
 
 
 const controlPanelFooter: CSSProperties = {
-    height: "20px",
+    height: "auto",
     marginBottom: "5px",
     paddingLeft: "2px",
     paddingRight: "2px",
@@ -246,7 +246,7 @@ const bugReport: CSSProperties = {
 
 const loadingMsgStyle: CSSProperties = {
     fontSize: "16px",
-    height: "20px",
+    height: "auto",
     marginTop: "6px",
 };
 


### PR DESCRIPTION
This PR has a small number of minor display fixes to prevent overlapping of various stuff:

 - The 'Stick Control Panel to Top' checkbox and the 'Displaying `n` toots' components are hidden on mobile: These don't make sense, as a sticky panel would hide the whole feed, and without sticky panel the 'displaying `n` toots` isn't visible on mobile.
 - Set some heights to `auto` to prevent overlap were text wraps into multiple lines on mobile.
 - Probably most controversial is that I've significantly reduced the header font size 'Fedialgo Demo', to better fit on mobile. This also affects Desktop, so you may not like it. I don't really know how I'd do this in a way that only affects mobile in your react app, as I'm not really very familiar with react. If you don't like this, please let me know and I'm happy to drop this commit from the PR.
 
Before:
<img width="413" alt="image" src="https://github.com/user-attachments/assets/da4b66c2-dcb4-43c5-96a3-3b43f9d3cc26" />
<img width="1657" alt="image" src="https://github.com/user-attachments/assets/1e948c2a-a700-40cd-b06b-026b17fd16d8" />


After: 
<img width="418" alt="image" src="https://github.com/user-attachments/assets/b3af92d0-7690-490a-8a2e-00af1007d8c2" />
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/a8c8955d-5789-446a-a817-fe9cc0aeac13" />
