### PR TITLE
Fix EISDIR error

### DIFF
--- a/serve_dist_bundle.js
+++ b/serve_dist_bundle.js
@@ -30,7 +30,7 @@ const prepareFile = async (url) => {
     console.log(`* [prepareFile] url: ${url}, baseUrl: ${baseUrl}`);
     let paths = [STATIC_PATH, baseUrl];
 
-    if (url.endsWith("/")) {
+    if (baseUrl.endsWith("/")) {
         paths.push("index.html");
     } else if (baseUrl.endsWith("/callback")) {
         paths = [STATIC_PATH, "index.html"];


### PR DESCRIPTION
I was getting the following error when logging in on the url `/?code=[redacted]`:

```
node:events:502
      throw er; // Unhandled 'error' event
Aug 05 06:19:35 mstdn node[350149]:       ^
Error: EISDIR: illegal operation on a directory, read
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -21,
  code: 'EISDIR',
  syscall: 'read'
```

This PR fixes this.