### PR TITLE
Mobile Support

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header(): JSX.Element {
             <Row className="w-100 m-1">
                 <Col xs={XS_VALUE} className="p-0">
                     {user &&
-                        <div className={`${ALIGN_MIDDLE_D_INLINE} ${TEXT_CENTER}`}>
+                        <div className={`${ALIGN_MIDDLE_D_INLINE} ${TEXT_CENTER}`} style={userContainer}>
                             {user?.profilePicture &&
                                 <img
                                     alt={`${FEDIALGO} User Avatar`}
@@ -33,7 +33,7 @@ export default function Header(): JSX.Element {
                                     style={avatarStyle}
                                 />}
 
-                            <span style={usernameStyle}>
+                            <span className="text-truncate" style={usernameStyle}>
                                 {user.username}
                             </span>
                         </div>}
@@ -48,10 +48,10 @@ export default function Header(): JSX.Element {
 
                     <span className={`${ALIGN_MIDDLE} ${TEXT_CENTER_P2}`} style={fedialgoContainer}>
                         <a href={config.app.repoUrl} style={whiteFont} target="_blank">
-                            Fedialgo Demo
+                            Fedialgo<span className="d-none d-sm-inline"> Demo</span>
                         </a>
 
-                        {" "}<span style={versionParenthesesStyle}>(
+                        {" "}<span className="d-none d-sm-inline" style={versionParenthesesStyle}>(
                             <a href={config.app.changelogUrl} style={versionStyle} target="_blank">
                                 v{process.env.FEDIALGO_VERSION}
                             </a>
@@ -87,9 +87,22 @@ const fedialgoContainer: CSSProperties = {
     whiteSpace: "nowrap",
 };
 
+const userContainer: CSSProperties = {
+    alignItems: "center",
+    display: "flex",
+    minWidth: 0,
+    overflow: "hidden",
+};
+
 const usernameStyle: CSSProperties = {
+    display: "inline-block",
     fontSize: TITLE_FONT_SIZE - 1,
-    padding: 10
+    maxWidth: "100%",
+    minWidth: 0,
+    overflow: "hidden",
+    paddingLeft: 10,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
 };
 
 const versionStyle: CSSProperties = {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,10 +21,10 @@ export default function Header(): JSX.Element {
 
     return (
         <Container className="w-100 m-1 app-header">
-            <Row className="w-100 m-1">
+            <Row className="w-100 m-1 align-items-center">
                 <Col xs={XS_VALUE} className="p-0">
                     {user &&
-                        <div className={`${ALIGN_MIDDLE_D_INLINE} ${TEXT_CENTER}`} style={userContainer}>
+                        <div className={`d-flex align-items-center ${TEXT_CENTER}`} style={userContainer}>
                             {user?.profilePicture &&
                                 <img
                                     alt={`${FEDIALGO} User Avatar`}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ export default function Header(): JSX.Element {
     const { logout, user } = useAuthContext();
 
     return (
-        <Container className="w-100 m-1">
+        <Container className="w-100 m-1 app-header">
             <Row className="w-100 m-1">
                 <Col xs={XS_VALUE} className="p-0">
                     {user &&

--- a/src/components/algorithm/FilterAccordionSection.tsx
+++ b/src/components/algorithm/FilterAccordionSection.tsx
@@ -57,9 +57,12 @@ const switchesContainer: CSSProperties = {
     ...boldFont,
     ...flexSpaceAround,
     ...centerAlignedFlexRow,
+    columnGap: "12px",
+    flexWrap: "wrap",
     fontSize: 16,
-    height: "25px",
     marginBottom: "3px",
+    minHeight: "25px",
+    rowGap: "4px",
 };
 
 const footerContainer: CSSProperties = {

--- a/src/components/algorithm/Slider.tsx
+++ b/src/components/algorithm/Slider.tsx
@@ -38,7 +38,7 @@ export default function Slider(props: SliderProps) {
     let divs = [
         <div key={`${label}_label`} style={labelContainer}>
             {!hideValueBox &&
-                <div style={sliderValue} id="innerest_doop">
+                <div className="slider-value-box" style={sliderValue} id="innerest_doop">
                     <span style={sliderValueFont}>
                         {value?.toFixed(decimals)}
                     </span>

--- a/src/components/algorithm/Slider.tsx
+++ b/src/components/algorithm/Slider.tsx
@@ -80,8 +80,8 @@ export default function Slider(props: SliderProps) {
 const labelContainer: CSSProperties = {
     ...centerAlignedFlexRow,
     fontSize: 14,
+    flexWrap: "wrap",
     justifyContent: "space-between",
-    textWrap: "nowrap",
 };
 
 const sliderContainer: CSSProperties = {

--- a/src/components/algorithm/Slider.tsx
+++ b/src/components/algorithm/Slider.tsx
@@ -69,7 +69,7 @@ export default function Slider(props: SliderProps) {
 
     return (
         <Form.Group className="me-2" key={`${label}_sliderForm`}>
-            <div style={{...labelContainer}}>
+            <div className="slider-row" style={{...labelContainer}}>
                 {hideValueBox ? divs.reverse() : divs}
             </div>
         </Form.Group>

--- a/src/components/status/MultimediaNode.tsx
+++ b/src/components/status/MultimediaNode.tsx
@@ -130,7 +130,7 @@ export default function MultimediaNode(props: MultimediaNodeProps): React.ReactE
         </>);
     } else if (videos.length > 0) {
         return (
-            <div className="media-gallery" style={{height: `${VIDEO_HEIGHT}px`, ...style}}>
+            <div className="media-gallery" style={{maxHeight: `${VIDEO_HEIGHT}px`, ...style}}>
                 {videos.map((video, i) => {
                     const sourceTag = <source src={video?.remoteUrl || video?.url} type="video/mp4" />;
                     const videoStyle = {...filterStyle, ...videoEmbedStyle};
@@ -139,13 +139,13 @@ export default function MultimediaNode(props: MultimediaNodeProps): React.ReactE
                     // GIFs autoplay play in a loop; mp4s are controlled by the user.
                     if (video.type == GIFV) {
                         videoTag = (
-                            <video autoPlay height={"100%"} loop playsInline style={videoStyle}>
+                            <video autoPlay loop playsInline style={videoStyle}>
                                 {sourceTag}
                             </video>
                         );
                     } else {
                         videoTag = (
-                            <video controls height={"100%"} playsInline style={videoStyle}>
+                            <video controls playsInline style={videoStyle}>
                                 {sourceTag}
                             </video>
                         );
@@ -198,14 +198,18 @@ const style: CSSProperties = {
 };
 
 const videoContainer: CSSProperties = {
-    ...fullSize,
     ...mediaItem,
     inset: "auto",
+    width: "100%",
 };
 
 const videoEmbedStyle: CSSProperties = {
     display: "block",
+    height: "auto",
     margin: "auto",
     marginLeft: "auto",
     marginRight: "auto",
+    maxHeight: `${VIDEO_HEIGHT}px`,
+    maxWidth: "100%",
+    width: "100%",
 };

--- a/src/components/status/MultimediaNode.tsx
+++ b/src/components/status/MultimediaNode.tsx
@@ -82,7 +82,7 @@ export default function MultimediaNode(props: MultimediaNodeProps): React.ReactE
                 className="media-gallery__item"
                 key={image.previewUrl}
                 style={{
-                    height: "100%",
+                    height: "auto",
                     inset: "auto",
                     width: 1 / images.length * 100 + "%"
                 }}
@@ -103,6 +103,7 @@ export default function MultimediaNode(props: MultimediaNodeProps): React.ReactE
                         ...filterStyle,
                         ...imageStyle,
                         cursor: removeMediaAttachment ? "default" : "pointer",
+                        maxHeight: `${imageHeight}px`,
                     }}
                     title={showContent ? image.description : spoilerText}
                     wrapperProps={{style: {position: "static"}}}  // Required to center properly with blur
@@ -123,7 +124,7 @@ export default function MultimediaNode(props: MultimediaNodeProps): React.ReactE
 
             <div
                 className="media-gallery"
-                style={{height: (images.length > 1 || imageHeight < 200) ? '100%' : `${imageHeight}px`, ...style}}
+                style={{maxHeight: `${imageHeight}px`, ...style}}
             >
                 {images.map((image, i) => makeImage(image, i))}
             </div>
@@ -185,12 +186,12 @@ const mediaItem: CSSProperties = {
 };
 
 const imageStyle: CSSProperties = {
-    ...fullSize,
     ...mediaItem,
-    // failed attempt at fake border
-    // filter: "drop-shadow(0 -5px 0 gray) drop-shadow(0 5px 0 gray) drop-shadow(-5px 0 0 gray) drop-shadow(5px 0 0 gray)",
+    height: "auto",
+    maxWidth: "100%",
     objectFit: "contain",
     objectPosition: "top",
+    width: "100%",
 };
 
 const style: CSSProperties = {

--- a/src/default.css
+++ b/src/default.css
@@ -3211,14 +3211,14 @@ body > [data-popper-placement] {
     margin:-3px 0 0
 }
 
-.reply-indicator__content p, .status__content p {
+.reply-indicator__content p, .status__content p, .status__content__text p {
     margin-bottom: 20px;
     white-space: pre-wrap;
     unicode-bidi: -moz-plaintext;
     unicode-bidi:plaintext
 }
 
-.reply-indicator__content p:last-child, .status__content p:last-child {
+.reply-indicator__content p:last-child, .status__content p:last-child, .status__content__text p:last-child {
     margin-bottom:0
 }
 

--- a/src/helpers/style_helpers.ts
+++ b/src/helpers/style_helpers.ts
@@ -254,11 +254,14 @@ export const roundedCorners: CSSProperties = {
 };
 
 export const stickySwitchContainer: CSSProperties = {
+    columnGap: "12px",
     display: "flex",
-    justifyContent: "space-between",
+    flexWrap: "wrap",
     height: "auto",
+    justifyContent: "space-between",
     paddingLeft: "2px",
     paddingRight: "2px",
+    rowGap: "4px",
 };
 
 export const titleStyle: CSSProperties = {

--- a/src/hooks/useIsMobile.tsx
+++ b/src/hooks/useIsMobile.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+// Matches Bootstrap's "md" breakpoint boundary (>= 768px is desktop).
+const MOBILE_QUERY = "(max-width: 767.98px)";
+
+/** Returns true when the viewport is narrower than Bootstrap's `md` breakpoint. */
+export default function useIsMobile(): boolean {
+    const getMatch = () =>
+        typeof window !== "undefined" && window.matchMedia(MOBILE_QUERY).matches;
+
+    const [isMobile, setIsMobile] = useState<boolean>(getMatch);
+
+    useEffect(() => {
+        const mql = window.matchMedia(MOBILE_QUERY);
+        const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+        mql.addEventListener("change", onChange);
+        return () => mql.removeEventListener("change", onChange);
+    }, []);
+
+    return isMobile;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -36,4 +36,24 @@ code {
   .slider-value-box {
     display: none !important;
   }
+
+  .offcanvas-body {
+    padding-left: 0.25rem !important;
+    padding-right: 0.25rem !important;
+  }
+
+  .offcanvas-body .accordion-body {
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
+  }
+
+  .offcanvas-body .accordion .accordion .accordion-body {
+    padding-left: 0.25rem !important;
+    padding-right: 0.25rem !important;
+  }
+
+  .offcanvas-body .status {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,17 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+@media (max-width: 767.98px) {
+  .accordion-body,
+  .accordion-body * {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    max-width: 100%;
+  }
+
+  .accordion-body img,
+  .accordion-body video {
+    height: auto;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,16 @@ code {
     padding-right: 12px !important;
   }
 
+  .container-fluid > .row {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  .container-fluid > .row > [class*="col"] {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
   .accordion-body,
   .accordion-body * {
     overflow-wrap: anywhere;

--- a/src/index.css
+++ b/src/index.css
@@ -32,4 +32,8 @@ code {
   .slider-row > * {
     width: 100%;
   }
+
+  .slider-value-box {
+    display: none !important;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -23,4 +23,13 @@ code {
   .accordion-body video {
     height: auto;
   }
+
+  .slider-row {
+    flex-direction: column;
+    align-items: stretch !important;
+  }
+
+  .slider-row > * {
+    width: 100%;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -56,4 +56,9 @@ code {
     padding-left: 0 !important;
     padding-right: 0 !important;
   }
+
+  .offcanvas-body .row > .col {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,17 @@ code {
 }
 
 @media (max-width: 767.98px) {
+  .container,
+  .container-fluid {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .container.app-header {
+    padding-left: 12px !important;
+    padding-right: 12px !important;
+  }
+
   .accordion-body,
   .accordion-body * {
     overflow-wrap: anywhere;

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -148,7 +148,7 @@ export default function Feed() {
     const controlPanelContent = (
         <>
             <div style={stickySwitchContainer}>
-                {isControlPanelStickyCheckbox}
+                {!isMobile && isControlPanelStickyCheckbox}
                 {showLinkPreviewsCheckbox}
                 {hideSensitiveCheckbox}
                 {shouldAutoUpdateCheckbox}
@@ -319,6 +319,7 @@ export default function Feed() {
 
 const accountTooltipStyle: CSSProperties = {
     ...tooltipZIndex,
+    maxWidth: "min(500px, 92vw)",
     width: "500px",
 };
 
@@ -344,9 +345,10 @@ const loadNewTootsText: CSSProperties = {
 
 const newTootButton: CSSProperties = {
     ...verticalContainer,
+    marginInline: "auto",
     marginTop: "35px",
-    marginLeft: "200px",
-    marginRight: "200px",
+    maxWidth: "300px",
+    width: "100%",
 };
 
 const mobileControlsDrawer: CSSProperties = {

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -88,15 +88,22 @@ export default function Feed() {
         if (isMobile && toots.length > 0) setShowMobileControls(true);
     };
 
+    // Open the mobile drawer as soon as the user taps "View Thread", so the loading
+    // indicator is visible while the network call is in flight.
+    useEffect(() => {
+        if (isMobile && isLoadingThread) setShowMobileControls(true);
+    }, [isLoadingThread, isMobile]);
+
     // When a thread is opened on mobile, wait for the offcanvas to finish opening, then scroll the
     // Thread accordion into view inside the drawer.
     useEffect(() => {
-        if (!isMobile || thread.length === 0 || !showMobileControls) return;
+        if (!isMobile || !showMobileControls) return;
+        if (thread.length === 0 && !isLoadingThread) return;
         const t = setTimeout(() => {
             threadRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
         }, 350);
         return () => clearTimeout(t);
-    }, [isMobile, thread, showMobileControls]);
+    }, [isMobile, isLoadingThread, thread, showMobileControls]);
 
     // Reset all state except for the user and server
     const reset = async () => {
@@ -159,17 +166,19 @@ export default function Feed() {
             {algorithm && <TrendingInfo />}
             {algorithm && <ExperimentalFeatures />}
 
-            {(thread.length > 0) &&
+            {(isLoadingThread || thread.length > 0) &&
                 <div ref={threadRef}>
                     <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
-                        {thread.map((toot) => (
-                            <StatusComponent
-                                fontColor="black"
-                                key={toot.uri}
-                                showLinkPreviews={showLinkPreviews}
-                                status={toot}
-                            />
-                        ))}
+                        {thread.length > 0
+                            ? thread.map((toot) => (
+                                <StatusComponent
+                                    fontColor="black"
+                                    key={toot.uri}
+                                    showLinkPreviews={showLinkPreviews}
+                                    status={toot}
+                                />
+                            ))
+                            : <LoadingSpinner message="Loading thread..." style={loadingMsgStyle} />}
                     </TopLevelAccordion>
                 </div>}
 

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -77,10 +77,26 @@ export default function Feed() {
 
     // Computed variables etc.
     const bottomRef = useRef<HTMLDivElement>(null);
+    const threadRef = useRef<HTMLDivElement>(null);
     const isBottom = useOnScreen(bottomRef);
     const isMobile = useIsMobile();
     const leftColStyle: CSSProperties = isControlPanelSticky ? {} : {position: "relative"};
     const numShownToots = Math.max(config.timeline.defaultNumDisplayedToots, numDisplayedToots);
+
+    const handleSetThread = (toots: Toot[]) => {
+        setThread(toots);
+        if (isMobile && toots.length > 0) setShowMobileControls(true);
+    };
+
+    // When a thread is opened on mobile, wait for the offcanvas to finish opening, then scroll the
+    // Thread accordion into view inside the drawer.
+    useEffect(() => {
+        if (!isMobile || thread.length === 0 || !showMobileControls) return;
+        const t = setTimeout(() => {
+            threadRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        }, 350);
+        return () => clearTimeout(t);
+    }, [isMobile, thread, showMobileControls]);
 
     // Reset all state except for the user and server
     const reset = async () => {
@@ -144,16 +160,18 @@ export default function Feed() {
             {algorithm && <ExperimentalFeatures />}
 
             {(thread.length > 0) &&
-                <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
-                    {thread.map((toot) => (
-                        <StatusComponent
-                            fontColor="black"
-                            key={toot.uri}
-                            showLinkPreviews={showLinkPreviews}
-                            status={toot}
-                        />
-                    ))}
-                </TopLevelAccordion>}
+                <div ref={threadRef}>
+                    <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
+                        {thread.map((toot) => (
+                            <StatusComponent
+                                fontColor="black"
+                                key={toot.uri}
+                                showLinkPreviews={showLinkPreviews}
+                                status={toot}
+                            />
+                        ))}
+                    </TopLevelAccordion>
+                </div>}
 
             <div style={stickySwitchContainer}>
                 {isLoading
@@ -278,7 +296,7 @@ export default function Feed() {
                             <StatusComponent
                                 isLoadingThread={isLoadingThread}
                                 key={toot.uri}
-                                setThread={setThread}
+                                setThread={handleSetThread}
                                 setIsLoadingThread={setIsLoadingThread}
                                 showLinkPreviews={showLinkPreviews}
                                 status={toot}

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -363,7 +363,7 @@ const newTootButton: CSSProperties = {
 const mobileControlsDrawer: CSSProperties = {
     backgroundColor: "#191b22",
     color: "#fff",
-    width: "min(420px, 92vw)",
+    width: "min(420px, 98vw)",
 };
 
 const mobileControlsFab: CSSProperties = {

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -19,6 +19,7 @@ import StatusComponent, { TOOLTIP_ACCOUNT_ANCHOR} from "../components/status/Sta
 import TooltippedLink from "../components/helpers/TooltippedLink";
 import TopLevelAccordion from "../components/helpers/TopLevelAccordion";
 import TrendingInfo from "../components/TrendingInfo";
+import useIsMobile from "../hooks/useIsMobile";
 import useOnScreen from "../hooks/useOnScreen";
 import WeightSetter from "../components/algorithm/WeightSetter";
 import { booleanIcon } from "../helpers/react_helpers";
@@ -76,6 +77,7 @@ export default function Feed() {
     // Computed variables etc.
     const bottomRef = useRef<HTMLDivElement>(null);
     const isBottom = useOnScreen(bottomRef);
+    const isMobile = useIsMobile();
     const leftColStyle: CSSProperties = isControlPanelSticky ? {} : {position: "relative"};
     const numShownToots = Math.max(config.timeline.defaultNumDisplayedToots, numDisplayedToots);
 
@@ -147,70 +149,90 @@ export default function Feed() {
 
                 <Col md={6} xs={12} >
                     {/* TODO: maybe the inset-inline-end property could be used to allow panel to scroll to length but still stick? */}
-                    <div className="sticky-top left-col-scroll" style={leftColStyle}>
-                        <div style={stickySwitchContainer}>
-                            {isControlPanelStickyCheckbox}
-                            {showLinkPreviewsCheckbox}
-                            {hideSensitiveCheckbox}
-                            {shouldAutoUpdateCheckbox}
-                        </div>
+                    {(() => {
+                        const controlPanelContent = (
+                            <>
+                                <div style={stickySwitchContainer}>
+                                    {isControlPanelStickyCheckbox}
+                                    {showLinkPreviewsCheckbox}
+                                    {hideSensitiveCheckbox}
+                                    {shouldAutoUpdateCheckbox}
+                                </div>
 
-                        {algorithm && <WeightSetter />}
-                        {algorithm && <FeedFiltersAccordionSection />}
-                        {algorithm && <TrendingInfo />}
-                        {algorithm && <ExperimentalFeatures />}
+                                {algorithm && <WeightSetter />}
+                                {algorithm && <FeedFiltersAccordionSection />}
+                                {algorithm && <TrendingInfo />}
+                                {algorithm && <ExperimentalFeatures />}
 
-                        {(thread.length > 0) &&
-                            <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
-                                {thread.map((toot) => (
-                                    <StatusComponent
-                                        fontColor="black"
-                                        key={toot.uri}
-                                        showLinkPreviews={showLinkPreviews}
-                                        status={toot}
-                                    />
-                                ))}
-                            </TopLevelAccordion>}
+                                {(thread.length > 0) &&
+                                    <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
+                                        {thread.map((toot) => (
+                                            <StatusComponent
+                                                fontColor="black"
+                                                key={toot.uri}
+                                                showLinkPreviews={showLinkPreviews}
+                                                status={toot}
+                                            />
+                                        ))}
+                                    </TopLevelAccordion>}
 
-                        <div style={stickySwitchContainer}>
-                            {isLoading
-                                ? <LoadingSpinner message={algorithm?.loadingStatus} style={loadingMsgStyle} />
-                                : <p style={loadingMsgStyle}>
-                                      {footerMsg} (
-                                          {<a onClick={reset} style={resetLinkStyle}>clear all data and reload</a>}
-                                      )
-                                  </p>}
+                                <div style={stickySwitchContainer}>
+                                    {isLoading
+                                        ? <LoadingSpinner message={algorithm?.loadingStatus} style={loadingMsgStyle} />
+                                        : <p style={loadingMsgStyle}>
+                                              {footerMsg} (
+                                                  {<a onClick={reset} style={resetLinkStyle}>clear all data and reload</a>}
+                                              )
+                                          </p>}
 
-                            <p style={scrollStatusMsg} className="d-none d-sm-block">
-                                {TheAlgorithm.isDebugMode
-                                    ? `Displaying ${numDisplayedToots} Toots (Scroll: ${scrollPercentage.toFixed(1)}%)`
-                                    : <BugReportLink />}
-                            </p>
-                        </div>
+                                    <p style={scrollStatusMsg} className="d-none d-sm-block">
+                                        {TheAlgorithm.isDebugMode
+                                            ? `Displaying ${numDisplayedToots} Toots (Scroll: ${scrollPercentage.toFixed(1)}%)`
+                                            : <BugReportLink />}
+                                    </p>
+                                </div>
 
-                        <div className="d-grid gap-2" style={newTootButton}>
-                            <Button
-                                className={TEXT_CENTER_P2}
-                                onClick={() => setShowNewTootModal(true)}
-                                variant="outline-secondary"
-                            >
-                                {`Create New Toot`}
-                            </Button>
-                        </div>
+                                <div className="d-grid gap-2" style={newTootButton}>
+                                    <Button
+                                        className={TEXT_CENTER_P2}
+                                        onClick={() => setShowNewTootModal(true)}
+                                        variant="outline-secondary"
+                                    >
+                                        {`Create New Toot`}
+                                    </Button>
+                                </div>
 
-                        {algorithm && <ApiErrorsPanel />}
+                                {algorithm && <ApiErrorsPanel />}
 
-                        {TheAlgorithm.isDebugMode &&
-                            <div style={envVarDebugPanel}>
-                                <ul>
-                                    <li><strong>NODE_ENV:</strong> {process.env.NODE_ENV}</li>
-                                    <li><strong>Debug Mode:</strong> {booleanIcon(TheAlgorithm.isDebugMode)}</li>
-                                    <li><strong>Deep Debug:</strong> {booleanIcon(TheAlgorithm.isDeepDebug)}</li>
-                                    <li><strong>Load Test:</strong> {booleanIcon(TheAlgorithm.isLoadTest)}</li>
-                                    <li><strong>Quick Mode:</strong> {booleanIcon(TheAlgorithm.isQuickMode)}</li>
-                                </ul>
-                            </div>}
-                    </div>
+                                {TheAlgorithm.isDebugMode &&
+                                    <div style={envVarDebugPanel}>
+                                        <ul>
+                                            <li><strong>NODE_ENV:</strong> {process.env.NODE_ENV}</li>
+                                            <li><strong>Debug Mode:</strong> {booleanIcon(TheAlgorithm.isDebugMode)}</li>
+                                            <li><strong>Deep Debug:</strong> {booleanIcon(TheAlgorithm.isDeepDebug)}</li>
+                                            <li><strong>Load Test:</strong> {booleanIcon(TheAlgorithm.isLoadTest)}</li>
+                                            <li><strong>Quick Mode:</strong> {booleanIcon(TheAlgorithm.isQuickMode)}</li>
+                                        </ul>
+                                    </div>}
+                            </>
+                        );
+
+                        if (isMobile) {
+                            return (
+                                <div style={mobileControlPanelWrapper}>
+                                    <TopLevelAccordion title="Controls & Filters">
+                                        {controlPanelContent}
+                                    </TopLevelAccordion>
+                                </div>
+                            );
+                        }
+
+                        return (
+                            <div className="sticky-md-top left-col-scroll" style={leftColStyle}>
+                                {controlPanelContent}
+                            </div>
+                        );
+                    })()}
                 </Col>
 
                 {/* Feed column */}
@@ -293,6 +315,10 @@ const newTootButton: CSSProperties = {
     marginTop: "35px",
     marginLeft: "200px",
     marginRight: "200px",
+};
+
+const mobileControlPanelWrapper: CSSProperties = {
+    marginBottom: "10px",
 };
 
 const noTootsMsgStyle: CSSProperties = {

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -3,7 +3,7 @@
  * weighting values.
  */
 import React, { CSSProperties, useEffect, useRef, useState } from "react";
-import { Button, Col, Container, Row } from "react-bootstrap";
+import { Button, Col, Container, Offcanvas, Row } from "react-bootstrap";
 
 import TheAlgorithm, { Toot, optionalSuffix } from "fedialgo";
 import { Tooltip } from "react-tooltip";
@@ -65,6 +65,7 @@ export default function Feed() {
     const [numDisplayedToots, setNumDisplayedToots] = useState<number>(config.timeline.defaultNumDisplayedToots);
     const [prevScrollY, setPrevScrollY] = useState(0);
     const [scrollPercentage, setScrollPercentage] = useState(0);
+    const [showMobileControls, setShowMobileControls] = useState(false);
     const [showNewTootModal, setShowNewTootModal] = useState(false);
     const [thread, setThread] = useState<Toot[]>([]);
 
@@ -128,9 +129,101 @@ export default function Feed() {
     let footerMsg = `Scored ${(timeline?.length || 0).toLocaleString()} toots`;
     footerMsg += optionalSuffix(lastLoadDurationSeconds, seconds => `in ${seconds.toFixed(1)} seconds`);
 
+    const controlPanelContent = (
+        <>
+            <div style={stickySwitchContainer}>
+                {isControlPanelStickyCheckbox}
+                {showLinkPreviewsCheckbox}
+                {hideSensitiveCheckbox}
+                {shouldAutoUpdateCheckbox}
+            </div>
+
+            {algorithm && <WeightSetter />}
+            {algorithm && <FeedFiltersAccordionSection />}
+            {algorithm && <TrendingInfo />}
+            {algorithm && <ExperimentalFeatures />}
+
+            {(thread.length > 0) &&
+                <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
+                    {thread.map((toot) => (
+                        <StatusComponent
+                            fontColor="black"
+                            key={toot.uri}
+                            showLinkPreviews={showLinkPreviews}
+                            status={toot}
+                        />
+                    ))}
+                </TopLevelAccordion>}
+
+            <div style={stickySwitchContainer}>
+                {isLoading
+                    ? <LoadingSpinner message={algorithm?.loadingStatus} style={loadingMsgStyle} />
+                    : <p style={loadingMsgStyle}>
+                          {footerMsg} (
+                              {<a onClick={reset} style={resetLinkStyle}>clear all data and reload</a>}
+                          )
+                      </p>}
+
+                <p style={scrollStatusMsg} className="d-none d-sm-block">
+                    {TheAlgorithm.isDebugMode
+                        ? `Displaying ${numDisplayedToots} Toots (Scroll: ${scrollPercentage.toFixed(1)}%)`
+                        : <BugReportLink />}
+                </p>
+            </div>
+
+            <div className="d-grid gap-2" style={newTootButton}>
+                <Button
+                    className={TEXT_CENTER_P2}
+                    onClick={() => setShowNewTootModal(true)}
+                    variant="outline-secondary"
+                >
+                    {`Create New Toot`}
+                </Button>
+            </div>
+
+            {algorithm && <ApiErrorsPanel />}
+
+            {TheAlgorithm.isDebugMode &&
+                <div style={envVarDebugPanel}>
+                    <ul>
+                        <li><strong>NODE_ENV:</strong> {process.env.NODE_ENV}</li>
+                        <li><strong>Debug Mode:</strong> {booleanIcon(TheAlgorithm.isDebugMode)}</li>
+                        <li><strong>Deep Debug:</strong> {booleanIcon(TheAlgorithm.isDeepDebug)}</li>
+                        <li><strong>Load Test:</strong> {booleanIcon(TheAlgorithm.isLoadTest)}</li>
+                        <li><strong>Quick Mode:</strong> {booleanIcon(TheAlgorithm.isQuickMode)}</li>
+                    </ul>
+                </div>}
+        </>
+    );
+
     return (
         <Container fluid style={{height: "auto"}}>
             <ReplyModal setShow={setShowNewTootModal} show={showNewTootModal}/>
+
+            {isMobile && (<>
+                <Button
+                    aria-label="Open controls and filters"
+                    onClick={() => setShowMobileControls(true)}
+                    style={mobileControlsFab}
+                    variant="primary"
+                >
+                    {"⚙"}
+                </Button>
+
+                <Offcanvas
+                    onHide={() => setShowMobileControls(false)}
+                    placement="end"
+                    show={showMobileControls}
+                    style={mobileControlsDrawer}
+                >
+                    <Offcanvas.Header closeButton closeVariant="white">
+                        <Offcanvas.Title>Controls & Filters</Offcanvas.Title>
+                    </Offcanvas.Header>
+                    <Offcanvas.Body>
+                        {controlPanelContent}
+                    </Offcanvas.Body>
+                </Offcanvas>
+            </>)}
 
             <Row style={waitOrDefaultCursor(isLoadingThread)}>
                 {/* Tooltip options: https://react-tooltip.com/docs/options */}
@@ -147,96 +240,17 @@ export default function Feed() {
 
                 {checkboxTooltip}
 
-                <Col md={6} xs={12} >
-                    {/* TODO: maybe the inset-inline-end property could be used to allow panel to scroll to length but still stick? */}
-                    {(() => {
-                        const controlPanelContent = (
-                            <>
-                                <div style={stickySwitchContainer}>
-                                    {isControlPanelStickyCheckbox}
-                                    {showLinkPreviewsCheckbox}
-                                    {hideSensitiveCheckbox}
-                                    {shouldAutoUpdateCheckbox}
-                                </div>
-
-                                {algorithm && <WeightSetter />}
-                                {algorithm && <FeedFiltersAccordionSection />}
-                                {algorithm && <TrendingInfo />}
-                                {algorithm && <ExperimentalFeatures />}
-
-                                {(thread.length > 0) &&
-                                    <TopLevelAccordion onExited={() => setThread([])} startOpen={true} title="Thread">
-                                        {thread.map((toot) => (
-                                            <StatusComponent
-                                                fontColor="black"
-                                                key={toot.uri}
-                                                showLinkPreviews={showLinkPreviews}
-                                                status={toot}
-                                            />
-                                        ))}
-                                    </TopLevelAccordion>}
-
-                                <div style={stickySwitchContainer}>
-                                    {isLoading
-                                        ? <LoadingSpinner message={algorithm?.loadingStatus} style={loadingMsgStyle} />
-                                        : <p style={loadingMsgStyle}>
-                                              {footerMsg} (
-                                                  {<a onClick={reset} style={resetLinkStyle}>clear all data and reload</a>}
-                                              )
-                                          </p>}
-
-                                    <p style={scrollStatusMsg} className="d-none d-sm-block">
-                                        {TheAlgorithm.isDebugMode
-                                            ? `Displaying ${numDisplayedToots} Toots (Scroll: ${scrollPercentage.toFixed(1)}%)`
-                                            : <BugReportLink />}
-                                    </p>
-                                </div>
-
-                                <div className="d-grid gap-2" style={newTootButton}>
-                                    <Button
-                                        className={TEXT_CENTER_P2}
-                                        onClick={() => setShowNewTootModal(true)}
-                                        variant="outline-secondary"
-                                    >
-                                        {`Create New Toot`}
-                                    </Button>
-                                </div>
-
-                                {algorithm && <ApiErrorsPanel />}
-
-                                {TheAlgorithm.isDebugMode &&
-                                    <div style={envVarDebugPanel}>
-                                        <ul>
-                                            <li><strong>NODE_ENV:</strong> {process.env.NODE_ENV}</li>
-                                            <li><strong>Debug Mode:</strong> {booleanIcon(TheAlgorithm.isDebugMode)}</li>
-                                            <li><strong>Deep Debug:</strong> {booleanIcon(TheAlgorithm.isDeepDebug)}</li>
-                                            <li><strong>Load Test:</strong> {booleanIcon(TheAlgorithm.isLoadTest)}</li>
-                                            <li><strong>Quick Mode:</strong> {booleanIcon(TheAlgorithm.isQuickMode)}</li>
-                                        </ul>
-                                    </div>}
-                            </>
-                        );
-
-                        if (isMobile) {
-                            return (
-                                <div style={mobileControlPanelWrapper}>
-                                    <TopLevelAccordion title="Controls & Filters">
-                                        {controlPanelContent}
-                                    </TopLevelAccordion>
-                                </div>
-                            );
-                        }
-
-                        return (
-                            <div className="sticky-md-top left-col-scroll" style={leftColStyle}>
-                                {controlPanelContent}
-                            </div>
-                        );
-                    })()}
-                </Col>
+                {!isMobile && (
+                    <Col md={6} xs={12} >
+                        {/* TODO: maybe the inset-inline-end property could be used to allow panel to scroll to length but still stick? */}
+                        <div className="sticky-md-top left-col-scroll" style={leftColStyle}>
+                            {controlPanelContent}
+                        </div>
+                    </Col>
+                )}
 
                 {/* Feed column */}
-                <Col xs={12} md={6}>
+                <Col xs={12} md={isMobile ? 12 : 6}>
                     {algorithm && !isLoading &&
                         <div style={loadNewTootsText}>
                             <TooltippedLink
@@ -317,8 +331,27 @@ const newTootButton: CSSProperties = {
     marginRight: "200px",
 };
 
-const mobileControlPanelWrapper: CSSProperties = {
-    marginBottom: "10px",
+const mobileControlsDrawer: CSSProperties = {
+    backgroundColor: "#191b22",
+    color: "#fff",
+    width: "min(420px, 92vw)",
+};
+
+const mobileControlsFab: CSSProperties = {
+    alignItems: "center",
+    borderRadius: "50%",
+    bottom: "20px",
+    boxShadow: "0 4px 12px rgba(0, 0, 0, 0.3)",
+    display: "flex",
+    fontSize: 24,
+    height: 56,
+    justifyContent: "center",
+    lineHeight: 1,
+    padding: 0,
+    position: "fixed",
+    right: "20px",
+    width: 56,
+    zIndex: 1040,
 };
 
 const noTootsMsgStyle: CSSProperties = {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -103,7 +103,7 @@ export default function LoginPage() {
             </div>
 
             <div style={serverContainer}>
-                <Form.Group className="mb-0">
+                <Form.Group className="mb-0" style={serverInputGroup}>
                     <Form.Control
                         id="mastodon_server"
                         onChange={(e) => setServerInputText(e.target.value)}
@@ -132,13 +132,13 @@ const descriptionText: CSSProperties = {
 const loginButtonStyle: CSSProperties = {
     display: "flex",
     justifyContent: "center",
-    marginLeft: "10px"
 };
 
 const loginContainer: CSSProperties = {
     ...centerAlignedFlexCol,
     flex: 1,
     justifyContent: "center",
+    paddingInline: "16px",
 };
 
 const previewImage: CSSProperties = {
@@ -146,6 +146,8 @@ const previewImage: CSSProperties = {
     border: "5px solid #DDD",
     boxShadow: "3px 3px 5px black",
     maxHeight: "550px",
+    maxWidth: "100%",
+    height: "auto",
 };
 
 const privacyText: CSSProperties = {
@@ -155,9 +157,19 @@ const privacyText: CSSProperties = {
     marginBottom: "20px",
 };
 
+const serverInputGroup: CSSProperties = {
+    flex: "1 1 240px",
+    maxWidth: "400px",
+    minWidth: 0,
+};
+
 const serverContainer: CSSProperties = {
+    columnGap: "10px",
     display: "flex",
-    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
     marginBottom: "5px",
-    marginTop: "5px"
+    marginTop: "5px",
+    rowGap: "10px",
+    width: "100%",
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,6 +117,8 @@ module.exports = {
                 /^offcanvas/,
                 /^accordion/,
                 /^status/,
+                /^row$/,
+                /^col$/,
             ]
         }),
         new WorkboxWebpackPlugin.GenerateSW({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,6 +114,9 @@ module.exports = {
                 /^invisible/,
                 /^form/,
                 /^media/,
+                /^offcanvas/,
+                /^accordion/,
+                /^status/,
             ]
         }),
         new WorkboxWebpackPlugin.GenerateSW({


### PR DESCRIPTION
This PR adds a responsive mobile experience while leaving desktop UX intact (with two minor exception, noted below):
  
**Mobile changes (`<768px`)**

  - The left control panel (weights, filters, trending, experimental) moves into a slide-in offcanvas drawer triggered by a floating `⚙` button. The feed gets the full viewport width.
  - Trending lists (hashtags, links, servers, favourited/participated tags) render single-column inside the drawer.
  - Long unbroken strings (URLs, handles, tags) break instead of forcing horizontal scroll.
  - Padding inside the drawer is trimmed so toots in the Thread panel get the full available width.
  - Header collapses gracefully: "Demo" + version are hidden, username truncates with ellipsis.
  - Login page: showcase image scales to viewport, server URL + Login button wrap onto two lines when needed.
  - "Stick Control Panel To Top" toggle is hidden inside the drawer, as it's irrelevant on mobile.
  - Tapping "View the Thread" opens the drawer immediately with the thread scrolled into view

**All screen sizes**
  - Videos in toots were being clipped by a fixed-height container with `overflow: hidden`. They now scale responsively so portrait and landscape videos display correctly on every viewport (limited by max-height so they never get too tall)
  - Images in toots had a fixed height, letterboxing at the bottom. They now scale responsively (limited by max-height so they never get too tall)
  - Click 'View Thread' shows a loading indicator while remote content is being loaded
  - Header is vertically aligned in the center)
  
**Implementation notes**
  - Bootstrap class names like `offcanvas-body`, `accordion-body`, `row`, `col` had to be added to PurgeCSS's safelist in `webpack.config.js`: react-bootstrap adds them at runtime, so PurgeCSS was silently stripping any rule that targeted them.
  - Mobile detection is a single `useIsMobile` hook keyed to Bootstrap's `md` breakpoint (768px).

**Preview URL**
  - I have deployed this to my demo at <https://fedialgo.thms.uk> if you want to see it in action.